### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint and Format Check


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/valkeylite/security/code-scanning/4](https://github.com/cyborginc/valkeylite/security/code-scanning/4)

The best way to fix the problem is to add an explicit `permissions` key at the root of the workflow file (above the `jobs:` key), applying least privilege. For these test/build jobs, only `contents: read` is reasonably required, as uploading artifacts does not require extra permissions, and the jobs do not interact with pull requests or issues.  
Therefore, add the block:
```yaml
permissions:
  contents: read
```
at the root, after the workflow `name` and `on:` blocks, and before `jobs:`. No further permissions are needed at job level.

Only `.github/workflows/pr-tests.yml` needs modification: insert the permissions block after `on:`, before `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
